### PR TITLE
Remove requests param for init container of prepull image

### DIFF
--- a/selenoid4k8s/templates/selenoid-k8s-prepull-deamonset.yaml
+++ b/selenoid4k8s/templates/selenoid-k8s-prepull-deamonset.yaml
@@ -28,9 +28,6 @@ spec:
         - grep image /etc/selenoid/browsers.json | awk '{print $2}' | tr -d ',' | tr -d '"' |
           xargs -I{} docker pull {}
         resources:
-          requests:
-            memory: "64Mi"
-            cpu: "150m"
           limits:
             memory: "128Mi"
             cpu: "500m"


### PR DESCRIPTION
Right now, daemonset cannot start if on node we have less then required resources, to fix that we can remove requests to add ability to start container without issues