### PR TITLE
Added minimal requests for init container of prepull images

### DIFF
--- a/selenoid4k8s/templates/selenoid-k8s-prepull-deamonset.yaml
+++ b/selenoid4k8s/templates/selenoid-k8s-prepull-deamonset.yaml
@@ -28,6 +28,9 @@ spec:
         - grep image /etc/selenoid/browsers.json | awk '{print $2}' | tr -d ',' | tr -d '"' |
           xargs -I{} docker pull {}
         resources:
+          requests:
+            memory: "16Mi"
+            cpu: "10m"
           limits:
             memory: "128Mi"
             cpu: "500m"


### PR DESCRIPTION
After removal of requests, observed that on running container it started usage of requests with the same as limits:

```yaml
    Limits:
      cpu:     500m
      memory:  128Mi
    Requests:
      cpu:        500m
      memory:     128Mi
```

So will add minimal requests to reduce issues