### PR TITLE
Update default chrome to 114 version

### DIFF
--- a/selenoid4k8s/Chart.yaml
+++ b/selenoid4k8s/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deploy Selenoid to Kubernetes
 name: selenoid4K8s
-version: 0.1.3
+version: 0.1.4

--- a/selenoid4k8s/values.yaml
+++ b/selenoid4k8s/values.yaml
@@ -95,10 +95,10 @@ config:
 
 browsers:
   chrome:
-    default: "86.0"
+    default: "114.0"
     versions:
-      "86.0":
-        image: "selenoid/vnc:chrome_86.0"
+      "114.0":
+        image: "selenoid/vnc:chrome_114.0"
         port: "4444"
         shmSize: 536870912
         resources:


### PR DESCRIPTION
- Chrome 86 version released in stable on October 6, 2020 - https://chromereleases.googleblog.com/2020/10/stable-channel-update-for-desktop.html
- Chrome 114 version released in stable on May 30, 2023 - https://chromereleases.googleblog.com/2023/05/stable-channel-update-for-desktop_30.html